### PR TITLE
Add D-Bus System interface and object

### DIFF
--- a/contrib/haos-agent.service
+++ b/contrib/haos-agent.service
@@ -4,7 +4,7 @@ Requires=dbus.service udisks2.service
 ConditionPathExists=/run/dbus/system_bus_socket
 
 [Service]
-Type=simple
+Type=notify
 Restart=always
 RestartSec=5s
 ExecStart=/usr/bin/os-agent

--- a/contrib/haos-agent.service
+++ b/contrib/haos-agent.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Home Assistant OS Agent
 Requires=dbus.service
-RequiresMountsFor=/mnt/data
 ConditionPathExists=/run/dbus/system_bus_socket
 
 [Service]

--- a/contrib/haos-agent.service
+++ b/contrib/haos-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Home Assistant OS Agent
-Requires=dbus.service
+Requires=dbus.service udisks2.service
 ConditionPathExists=/run/dbus/system_bus_socket
 
 [Service]

--- a/datadisk/datadisk.go
+++ b/datadisk/datadisk.go
@@ -43,7 +43,7 @@ func (d datadisk) ChangeDevice(newDevice string) (bool, *dbus.Error) {
 	fmt.Printf("Request to change data disk to %s.\n", newDevice)
 
 	udisks2helper := udisks2.NewUDisks2(d.conn)
-	dataDevice, err := udisks2helper.GetDeviceFromLabel("hassos-data")
+	dataDevice, err := udisks2helper.GetRootDeviceFromLabel("hassos-data")
 	if err != nil {
 		return false, dbus.MakeFailedError(err)
 	}
@@ -53,7 +53,7 @@ func (d datadisk) ChangeDevice(newDevice string) (bool, *dbus.Error) {
 		return false, dbus.MakeFailedError(fmt.Errorf("Current data device \"%s\" the same as target device. Aborting.", *dataDevice))
 	}
 
-	err = udisks2helper.FormatDeviceWithSinglePartition(newDevice, linuxDataPartitionUUID, "hassos-data-external")
+	err = udisks2helper.PartitionDeviceWithSinglePartition(newDevice, linuxDataPartitionUUID, "hassos-data-external")
 	if err != nil {
 		return false, dbus.MakeFailedError(err)
 	}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/home-assistant/os-agent/datadisk"
+	"github.com/home-assistant/os-agent/system"
 
 	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/godbus/dbus/v5"
@@ -33,6 +34,7 @@ func main() {
 
 	fmt.Printf("Listening on service %s ...\n", busName)
 	datadisk.InitializeDBus(conn)
+	system.InitializeDBus(conn)
 
 	daemon.SdNotify(false, daemon.SdNotifyReady)
 	select {}

--- a/system/system.go
+++ b/system/system.go
@@ -39,7 +39,7 @@ func getAndCheckBusObjectFromLabel(udisks2helper udisks2.UDisks2Helper, label st
 	return dataBusObject, nil
 }
 
-func (d system) FactoryReset() (bool, *dbus.Error) {
+func (d system) WipeDevice() (bool, *dbus.Error) {
 	fmt.Printf("Wipe device data.\n")
 
 	udisks2helper := udisks2.NewUDisks2(d.conn)

--- a/system/system.go
+++ b/system/system.go
@@ -60,11 +60,11 @@ func (d system) FactoryReset() (bool, *dbus.Error) {
 		return false, dbus.MakeFailedError(err)
 	}
 
-	err = udisks2helper.FormatPartition(*dataDevice, "ext4")
+	err = udisks2helper.FormatPartition(*dataDevice, "ext4", "hassos-data")
 	if err != nil {
 		return false, dbus.MakeFailedError(err)
 	}
-	err = udisks2helper.FormatPartition(*overlayDevice, "ext4")
+	err = udisks2helper.FormatPartition(*overlayDevice, "ext4", "hassos-overlay")
 	if err != nil {
 		return false, dbus.MakeFailedError(err)
 	}

--- a/system/system.go
+++ b/system/system.go
@@ -1,0 +1,109 @@
+package system
+
+import (
+	"fmt"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
+	"github.com/home-assistant/os-agent/udisks2"
+
+	systemddbus "github.com/coreos/go-systemd/v22/dbus"
+)
+
+const (
+	objectPath = "/io/homeassistant/os/System"
+	ifaceName  = "io.homeassistant.os.System"
+)
+
+type system struct {
+	conn *dbus.Conn
+}
+
+func SystemdIsolate(c *systemddbus.Conn, target string) error {
+	result := make(chan string, 1) // catch result information
+	_, err := c.StartUnit(target, "isolate", result)
+	if err != nil {
+		return err
+	}
+	if result == nil {
+		return fmt.Errorf("Isolating haos-maintenance.target failed: Result is nil")
+	}
+
+	status := <-result
+	if status != "done" {
+		return fmt.Errorf("Isolating haos-maintenance.target failed: Unknown return string: %s", status)
+	}
+
+	return nil
+}
+
+func (d system) FactoryReset() (bool, *dbus.Error) {
+	fmt.Printf("Factory resetting this device.\n")
+
+	c, err := systemddbus.NewSystemConnection()
+	if err != nil {
+		return false, dbus.MakeFailedError(err)
+	}
+	err = SystemdIsolate(c, "haos-maintenance.target")
+	if err != nil {
+		return false, dbus.MakeFailedError(err)
+	}
+
+	udisks2helper := udisks2.NewUDisks2(d.conn)
+	dataDevice, err := udisks2helper.GetPartitionDeviceFromLabel("hassos-data")
+	if err != nil {
+		return false, dbus.MakeFailedError(err)
+	}
+
+	overlayDevice, err := udisks2helper.GetPartitionDeviceFromLabel("hassos-overlay")
+	if err != nil {
+		return false, dbus.MakeFailedError(err)
+	}
+
+	err = udisks2helper.FormatPartition(*dataDevice, "ext4")
+	if err != nil {
+		return false, dbus.MakeFailedError(err)
+	}
+	err = udisks2helper.FormatPartition(*overlayDevice, "ext4")
+	if err != nil {
+		return false, dbus.MakeFailedError(err)
+	}
+
+	err = SystemdIsolate(c, "default.target")
+	if err != nil {
+		return false, dbus.MakeFailedError(err)
+	}
+
+	return true, nil
+}
+
+func InitializeDBus(conn *dbus.Conn) {
+	d := system{
+		conn: conn,
+	}
+
+	err := conn.Export(d, objectPath, ifaceName)
+	if err != nil {
+		panic(err)
+	}
+
+	node := &introspect.Node{}
+	node.Name = ifaceName
+	iface := &introspect.Interface{}
+
+	iface.Name = ifaceName
+
+	mts := introspect.Methods(d)
+	iface.Methods = mts
+
+	node.Interfaces = append(node.Interfaces, *iface)
+
+	dbus_xml_str := introspect.NewIntrospectable(node)
+	err = conn.Export(dbus_xml_str, objectPath,
+		"org.freedesktop.DBus.Introspectable")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Exposing object %s with interface %s ...\n", objectPath, ifaceName)
+}

--- a/udisks2/apiutils.go
+++ b/udisks2/apiutils.go
@@ -21,6 +21,21 @@ func (o *Block) GetDeviceString(ctx context.Context) (*string, error) {
 	return &s, nil
 }
 
+func (f *Filesystem) GetMountPointsString(ctx context.Context) ([]string, error) {
+	dataMountPoints, err := f.GetMountPoints(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dataMountPointsString := make([]string, len(dataMountPoints))
+	for i, ba := range dataMountPoints {
+		s := strings.Trim(string(ba), "\x00")
+		dataMountPointsString[i] = s
+	}
+
+	return dataMountPointsString, nil
+}
+
 func (m *Manager) ResolveDeviceFromLabel(label string) (*dbus.ObjectPath, error) {
 	devspec := map[string]dbus.Variant{"label": dbus.MakeVariant(label)}
 	blockObjects, err := m.ResolveDevice(context.Background(), devspec, noOptions)

--- a/udisks2/apiutils.go
+++ b/udisks2/apiutils.go
@@ -1,0 +1,37 @@
+package udisks2
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/godbus/dbus/v5"
+)
+
+var noOptions = map[string]dbus.Variant{}
+
+func (o *Block) GetDeviceString(ctx context.Context) (*string, error) {
+
+	device, err := o.GetDevice(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s := strings.Trim(string(device), "\x00")
+	return &s, nil
+}
+
+func (m *Manager) ResolveDeviceFromLabel(label string) (*dbus.ObjectPath, error) {
+	devspec := map[string]dbus.Variant{"label": dbus.MakeVariant(label)}
+	blockObjects, err := m.ResolveDevice(context.Background(), devspec, noOptions)
+
+	if err != nil {
+		return nil, err
+	}
+	if len(blockObjects) != 1 {
+		return nil, fmt.Errorf("Expected single block device with file system label \"%s\", found %d", label, len(blockObjects))
+	}
+
+	/* Get Partition object of the data partition */
+	return &blockObjects[0], nil
+}

--- a/udisks2/helper.go
+++ b/udisks2/helper.go
@@ -27,11 +27,11 @@ func NewUDisks2(conn *dbus.Conn) UDisks2Helper {
 func (u UDisks2Helper) GetPartitionDeviceFromLabel(label string) (*string, error) {
 
 	busObject, err := u.manager.ResolveDeviceFromLabel(label)
-	busObjectBlock := u.conn.Object("org.freedesktop.UDisks2", *busObject)
 	if err != nil {
 		return nil, err
 	}
 
+	busObjectBlock := u.conn.Object("org.freedesktop.UDisks2", *busObject)
 	block := NewBlock(busObjectBlock)
 
 	return block.GetDeviceString(context.Background())
@@ -40,11 +40,11 @@ func (u UDisks2Helper) GetPartitionDeviceFromLabel(label string) (*string, error
 func (u UDisks2Helper) GetRootDeviceFromLabel(label string) (*string, error) {
 
 	busObject, err := u.manager.ResolveDeviceFromLabel(label)
-	busObjectBlock := u.conn.Object("org.freedesktop.UDisks2", *busObject)
 	if err != nil {
 		return nil, err
 	}
 
+	busObjectBlock := u.conn.Object("org.freedesktop.UDisks2", *busObject)
 	partition := NewPartition(busObjectBlock)
 	table, err := partition.GetTable(context.Background())
 	if err != nil {

--- a/udisks2/helper.go
+++ b/udisks2/helper.go
@@ -58,7 +58,7 @@ func (u UDisks2Helper) GetRootDeviceFromLabel(label string) (*string, error) {
 	return parentBlock.GetDeviceString(context.Background())
 }
 
-func (u UDisks2Helper) FormatPartition(devicePath string, fsType string) error {
+func (u UDisks2Helper) FormatPartition(devicePath string, fsType string, label string) error {
 	devspec := map[string]dbus.Variant{"path": dbus.MakeVariant(devicePath)}
 	blockObjects, err := u.manager.ResolveDevice(context.Background(), devspec, noOptions)
 	if err != nil {
@@ -72,7 +72,8 @@ func (u UDisks2Helper) FormatPartition(devicePath string, fsType string) error {
 	blockObjectPath := blockObjects[0]
 	busObjectParentBlock := u.conn.Object("org.freedesktop.UDisks2", blockObjectPath)
 	parentBlock := NewBlock(busObjectParentBlock)
-	err = parentBlock.Format(context.Background(), fsType, noOptions)
+	formatOptions := map[string]dbus.Variant{"label": dbus.MakeVariant(label)}
+	err = parentBlock.Format(context.Background(), fsType, formatOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This new interface allows to trigger a device wipe which causes the OS Agent to format the overlay as well as the data partition.

Note: This feature currently can only be used when the partitions are not mounted. The wipe therefor has to be triggered early during boot.