### PR TITLE
Use short name for internal usage

### DIFF
--- a/.devcontainer/dbus.sh
+++ b/.devcontainer/dbus.sh
@@ -20,4 +20,4 @@ function init_dbus() {
 }
 
 init_dbus
-cp contrib/io.homeassistant.conf /etc/dbus-1/system.d/
+cp contrib/io.hass.conf /etc/dbus-1/system.d/

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ go build -ldflags "-X main.version="
 ## Tests
 
 ```sh
-$ gdbus introspect --system --dest io.homeassistant.os --object-path /io/homeassistant/os
+$ gdbus introspect --system --dest io.hass.os --object-path /io/hass/os
 ```

--- a/apparmor/apparmor.go
+++ b/apparmor/apparmor.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	objectPath        = "/io/homeassistant/os/AppArmor"
-	ifaceName         = "io.homeassistant.os.AppArmor"
+	objectPath        = "/io/hass/os/AppArmor"
+	ifaceName         = "io.hass.os.AppArmor"
 	appArmorParserCmd = "apparmor_parser"
 )
 

--- a/cgroup/cgroup.go
+++ b/cgroup/cgroup.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	objectPath            = "/io/homeassistant/os/CGroup"
-	ifaceName             = "io.homeassistant.os.CGroup"
+	objectPath            = "/io/hass/os/CGroup"
+	ifaceName             = "io.hass.os.CGroup"
 	cgroupFSDockerDevices = "/sys/fs/cgroup/devices/docker"
 )
 

--- a/contrib/haos-agent.service
+++ b/contrib/haos-agent.service
@@ -5,6 +5,7 @@ Requires=dbus.socket udisks2.service
 After=dbus.socket
 
 [Service]
+BusName=io.hass.os
 Type=notify
 Restart=always
 RestartSec=5s

--- a/contrib/io.hass.conf
+++ b/contrib/io.hass.conf
@@ -4,14 +4,14 @@
 <busconfig>
   <!-- Only root can own the Home Assitant OS service -->
   <policy user="root">
-    <allow own="io.homeassistant.os"/>
+    <allow own="io.hass.os"/>
   </policy>
   <policy group="root">
-    <allow own="io.homeassistant.os"/>
+    <allow own="io.hass.os"/>
   </policy>
 
   <policy context="default">
-    <allow send_destination="io.homeassistant.os"/>
-    <allow receive_sender="io.homeassistant.os"/>
+    <allow send_destination="io.hass.os"/>
+    <allow receive_sender="io.hass.os"/>
   </policy>
 </busconfig>

--- a/datadisk/datadisk.go
+++ b/datadisk/datadisk.go
@@ -74,8 +74,8 @@ func (d datadisk) ChangeDevice(newDevice string) (bool, *dbus.Error) {
 }
 
 const (
-	objectPath = "/io/homeassistant/os/DataDisk"
-	ifaceName  = "io.homeassistant.os.DataDisk"
+	objectPath = "/io/hass/os/DataDisk"
+	ifaceName  = "io.hass.os.DataDisk"
 )
 
 func InitializeDBus(conn *dbus.Conn) {

--- a/main.go
+++ b/main.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	busName    = "io.homeassistant.os"
-	objectPath = "/io/homeassistant/os"
+	busName    = "io.hass.os"
+	objectPath = "/io/hass/os"
 )
 
 var version string

--- a/system/system.go
+++ b/system/system.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	objectPath             = "/io/homeassistant/os/System"
-	ifaceName              = "io.homeassistant.os.System"
+	objectPath             = "/io/hass/os/System"
+	ifaceName              = "io.hass.os.System"
 	labelDataFileSystem    = "hassos-data"
 	labelOverlayFileSystem = "hassos-overlay"
 	kernelCommandLine      = "/mnt/boot/cmdline.txt"


### PR DESCRIPTION
Move to hass.io as we use for all our internal platform names:
- Network
- Bus between core and supervisor
- Docker tags
- DNS / internal hostnames