### PR TITLE
Remove tar distribution

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,17 +20,6 @@ builds:
       - 5
       - 7
 
-archives:
-  - replacements:
-      386: i386
-      amd64: x86_64
-      arm64: aarch64
-    wrap_in_directory: true
-    files:
-      - LICENSE
-      - contrib/haos-agent.service
-      - contrib/io.hass.conf
-
 checksum:
   name_template: checksums.txt
   algorithm: sha512


### PR DESCRIPTION
It's already baked in for Home Assistant OS and in the case of Supervised, we only support systems that accept the `deb`. So we have no need to distribute the `.tar.gz` files at this point.

