### PR TITLE
Don't fail if apparmor_parser is missing

### DIFF
--- a/apparmor/apparmor.go
+++ b/apparmor/apparmor.go
@@ -27,7 +27,8 @@ func getAppArmorVersion() string {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logging.Critical.Panic(err)
+		logging.Warning.Print(err)
+		return string("")
 	}
 
 	re := regexp.MustCompile("version ([0-9.]*)")


### PR DESCRIPTION
Currently a missing apparmor_parser binary leads to a panic at startup
already since the property value gets evaluated when the propery is
registred.

Set the property to an empty string if apparmor_parser is missing. This
will allow to generate a sensible warning in Supervisor so the user can
act on it.