### PR TITLE
Disable Sentry by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ const (
 
 var (
 	version       string = "dev"
-	enableCapture bool   = true
+	enableCapture bool   = false
 )
 
 func main() {


### PR DESCRIPTION
Only enable Sentry if explicitly enabled by the user even on startup.