### PR TITLE
Use boardnames dbus style

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
     ldflags:
       - -s -w
       - -X main.version={{.Version}}
-      - -X main.board=supervised
+      - -X main.board=Supervised
     goos:
       - linux
     goarch:

--- a/boards/boards.go
+++ b/boards/boards.go
@@ -68,9 +68,9 @@ func InitializeDBus(conn *dbus.Conn, board string) {
 	logging.Info.Printf("Exposing object %s with interface %s ...", objectPath, ifaceName)
 
 	// Initialize the board
-	if board == "yellow" {
+	if board == "Yellow" {
 		yellow.InitializeDBus(conn)
-	} else if board == "supervised" {
+	} else if board == "Supervised" {
 		supervised.InitializeDBus(conn)
 	} else {
 		logging.Info.Printf("No specific Board features for %s", board)


### PR DESCRIPTION
I use that board property to know which features set I have to load. But currently the board and dbus path don't match which need later a mapping that make not a lot sense