### PR TITLE
Add API to trigger data disk move only

### DIFF
--- a/datadisk/datadisk.go
+++ b/datadisk/datadisk.go
@@ -74,9 +74,9 @@ func (d datadisk) ChangeDevice(newDevice string) (bool, *dbus.Error) {
 		return false, dbus.MakeFailedError(err)
 	}
 
-	err = d.MarkDataMove()
-	if err != nil {
-		return false, dbus.MakeFailedError(err)
+	dbuserr := d.MarkDataMove()
+	if dbuserr != nil {
+		return false, dbuserr
 	}
 
 	return true, nil

--- a/datadisk/datadisk.go
+++ b/datadisk/datadisk.go
@@ -40,6 +40,21 @@ type datadisk struct {
 	props *prop.Properties
 }
 
+func (d datadisk) MarkDataMove() (bool, *dbus.Error) {
+	/* Move request marker for hassos-data.service */
+	fileName := "/mnt/overlay/move-data"
+	_, err := os.Stat(fileName)
+	if os.IsNotExist(err) {
+		file, err := os.Create(fileName)
+		if err != nil {
+			return false, dbus.MakeFailedError(err)
+		}
+		defer file.Close()
+	}
+
+	return true, nil
+}
+
 func (d datadisk) ChangeDevice(newDevice string) (bool, *dbus.Error) {
 	logging.Info.Printf("Request to change data disk to %s.", newDevice)
 
@@ -59,18 +74,7 @@ func (d datadisk) ChangeDevice(newDevice string) (bool, *dbus.Error) {
 		return false, dbus.MakeFailedError(err)
 	}
 
-	/* Move request marker for hassos-data.service */
-	fileName := "/mnt/overlay/move-data"
-	_, err = os.Stat(fileName)
-	if os.IsNotExist(err) {
-		file, err := os.Create(fileName)
-		if err != nil {
-			return false, dbus.MakeFailedError(err)
-		}
-		defer file.Close()
-	}
-
-	return true, nil
+	return d.MarkDataMove()
 }
 
 func (d datadisk) ReloadDevice() (bool, *dbus.Error) {

--- a/datadisk/datadisk.go
+++ b/datadisk/datadisk.go
@@ -40,19 +40,19 @@ type datadisk struct {
 	props *prop.Properties
 }
 
-func (d datadisk) MarkDataMove() (bool, *dbus.Error) {
+func (d datadisk) MarkDataMove() *dbus.Error {
 	/* Move request marker for hassos-data.service */
 	fileName := "/mnt/overlay/move-data"
 	_, err := os.Stat(fileName)
 	if os.IsNotExist(err) {
 		file, err := os.Create(fileName)
 		if err != nil {
-			return false, dbus.MakeFailedError(err)
+			return dbus.MakeFailedError(err)
 		}
 		defer file.Close()
 	}
 
-	return true, nil
+	return nil
 }
 
 func (d datadisk) ChangeDevice(newDevice string) (bool, *dbus.Error) {
@@ -74,7 +74,12 @@ func (d datadisk) ChangeDevice(newDevice string) (bool, *dbus.Error) {
 		return false, dbus.MakeFailedError(err)
 	}
 
-	return d.MarkDataMove()
+	err = d.MarkDataMove()
+	if err != nil {
+		return false, dbus.MakeFailedError(err)
+	}
+
+	return true, nil
 }
 
 func (d datadisk) ReloadDevice() (bool, *dbus.Error) {


### PR DESCRIPTION
Add a new D-Bus API which allows to trigger the data disk move only. This allows to handle the selection and partitioning from Supervisor directly (via UDisks2 D-Bus API). Handling partitioning directly in Supervisor should improve device detection/selection and allows for better error handling.

Before calling this API, make sure to prepare a data disk using the GPT partition layout and with the partition label (not file system label) of `hassos-data-external`. Then call the API without argument and reboot the system.

```
# busctl --verbose call io.hass.os /io/hass/os/DataDisk io.hass.os.DataDisk MarkDataMove
```