### PR TITLE
Check if errors are handled in golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,4 +14,3 @@ jobs:
         uses: golangci/golangci-lint-action@v3.4.0
         with:
           version: latest
-          args: -D errcheck

--- a/cgroup/cgroup.go
+++ b/cgroup/cgroup.go
@@ -54,7 +54,12 @@ func (d cgroup) AddDevicesAllowed(containerID string, permission string) (bool, 
 			return false, dbus.MakeFailedError(error)
 		}
 		enc := json.NewEncoder(stdin)
-		enc.Encode(resources)
+		err = enc.Encode(resources)
+		if err != nil {
+			error := fmt.Errorf("Error encoding JSON for '%s': %s", containerID, err)
+			logging.Error.Printf("%s", error)
+			return false, dbus.MakeFailedError(error)
+		}
 		stdin.Close()
 
 		stdoutStderr, err := cmd.CombinedOutput()


### PR DESCRIPTION
Fix the only instance where this isn't beeing done properly and enable the CI check by default.