### PR TITLE
Fix file_name_template to produce the same binary names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,12 +43,14 @@ nfpms:
     dependencies:
       - udisks2
     file_name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
+      {{ .PackageName }}_{{ .Version }}_{{ .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else if eq .Arch "arm64" }}aarch64
-      {{- else }}{{ .Arch }}{{ end }}
+      {{- else }}
+      {{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}
+      {{ with .Mips }}_{{ . }}{{ end }}
+      {{ end }}
     contents:
       - src: contrib/haos-agent.service
         dst: /usr/lib/systemd/system/haos-agent.service


### PR DESCRIPTION
Unfortunately, the [nfpms.replacements example](https://goreleaser.com/deprecations/#nfpmsreplacements) is not based on a default configuration. The example causes ARM binaries to be named differently.

Use default `file_name_template` as base and implement our replacements based on that.