### PR TITLE
Fix dot in Arm binary builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,8 +47,7 @@ nfpms:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else if eq .Arch "arm64" }}aarch64
-      {{- else }}
-      {{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}
+      {{- else }}{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}
       {{ with .Mips }}_{{ . }}{{ end }}
       {{ end }}
     contents:


### PR DESCRIPTION
It seems the newline causes a dot to be inserted in the deb binaries for Arm.