### PR TITLE
Declare GoReleaser config version to suppress warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: os-agent
 before:
   hooks:


### PR DESCRIPTION
GoReleaser v2 introduced in #201 now complains about missing configuration version, so make it happy by adding it.