### PR TITLE
Update to Go 1.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 env:
-  GOLANG_VERSION: "1.20"
+  GOLANG_VERSION: "1.24"
 
 jobs:
   build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-assistant/os-agent
 
-go 1.19
+go 1.24
 
 require (
 	github.com/coreos/go-systemd/v22 v22.5.0


### PR DESCRIPTION
Use latest Go 1.24 for build and sync it with the go directive in go.mod.