### PR TITLE
Lower required Go version to 1.22 to fix OS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 env:
-  GOLANG_VERSION: "1.24"
+  GOLANG_VERSION: "1.22"
 
 jobs:
   build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-assistant/os-agent
 
-go 1.24
+go 1.22
 
 require (
 	github.com/coreos/go-systemd/v22 v22.5.0


### PR DESCRIPTION
Host Go in Buildroot version used by OS is currently 1.22.x. Since Go >= 1.21 actually checks that the used version is at least the one defined in go directive, build of os-agent package fails. Lower to 1.22, as the latest version is not required anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build environment and dependency configuration to use Go version 1.22 for enhanced consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->