### PR TITLE
Start OS Agent Systemd service after sysinit.target

### DIFF
--- a/contrib/haos-agent.service
+++ b/contrib/haos-agent.service
@@ -2,7 +2,7 @@
 Description=Home Assistant OS Agent
 DefaultDependencies=no
 Requires=dbus.socket udisks2.service
-After=dbus.socket
+After=dbus.socket sysinit.target
 
 [Service]
 BusName=io.hass.os


### PR DESCRIPTION
As OS Agent accesses various system features, it should be mandatory that all mounts have been created and the system is mostly initialized. This should be the sysinit.target - at this point everything should be up and only various services should be being initialized (those would need to be specified explicitly).

A concrete example of this target being needed is systemd-sysctl.service - without that finished, OS Agent may get wrong kernel parameters which are later set via that service.