### PR TITLE
Use background Context for AppArmor/runc commands

### DIFF
--- a/apparmor/apparmor.go
+++ b/apparmor/apparmor.go
@@ -1,9 +1,11 @@
 package apparmor
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"regexp"
+	"time"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
@@ -24,7 +26,9 @@ type apparmor struct {
 }
 
 func getAppArmorVersion() string {
-	cmd := exec.Command(appArmorParserCmd, "--version")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, appArmorParserCmd, "--version")
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -44,7 +48,9 @@ func getAppArmorVersion() string {
 func (d apparmor) LoadProfile(profilePath string, cachePath string) (bool, *dbus.Error) {
 	logging.Info.Printf("Load AppArmor profile '%s'.", profilePath)
 
-	cmd := exec.Command(appArmorParserCmd, "--replace", "--write-cache", "--cache-loc", cachePath, profilePath)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, appArmorParserCmd, "--replace", "--write-cache", "--cache-loc", cachePath, profilePath)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, dbus.MakeFailedError(fmt.Errorf("can't load profile '%s': %w", profilePath, err))
@@ -57,7 +63,9 @@ func (d apparmor) LoadProfile(profilePath string, cachePath string) (bool, *dbus
 func (d apparmor) UnloadProfile(profilePath string, cachePath string) (bool, *dbus.Error) {
 	logging.Info.Printf("Unload AppArmor profile '%s'.", profilePath)
 
-	cmd := exec.Command(appArmorParserCmd, "--remove", "--write-cache", "--cache-loc", cachePath, profilePath)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, appArmorParserCmd, "--remove", "--write-cache", "--cache-loc", cachePath, profilePath)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cgroup/cgroup.go
+++ b/cgroup/cgroup.go
@@ -1,11 +1,13 @@
 package cgroup
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/godbus/dbus/v5"
@@ -44,7 +46,9 @@ func (d cgroup) AddDevicesAllowed(containerID string, permission string) (bool, 
 			return false, dbus.MakeFailedError(error)
 		}
 
-		cmd := exec.Command("runc", "--root", "/var/run/docker/runtime-runc/moby/", "update", "--resources", "-", containerID)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "runc", "--root", "/var/run/docker/runtime-runc/moby/", "update", "--resources", "-", containerID)
 
 		// Pass resources as OCI LinuxResources JSON object
 		stdin, err := cmd.StdinPipe()


### PR DESCRIPTION
This addresses golang-lint errors about missing context for exec.Command() operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rare hangs during AppArmor operations by adding short timeouts; profile load/unload now fail fast (10s) and version checks time out quickly (2s), improving responsiveness and error clarity.
  * Avoided potential stalls when updating cgroups by adding a 10s timeout, ensuring operations cancel promptly on unexpected delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->