### PR TITLE
Update devcontainer Go version to 1.26

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:2.1.0": {
+      "version": "2.1.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
+      "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,16 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VARIANT": "1.19-bullseye",
+			"VARIANT": "1.26",
 			"NODE_VERSION": "none"
 		}
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/node:2.1.0": {
+			"version": "lts"
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
 	},
 	"postCreateCommand": "go mod download",
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],


### PR DESCRIPTION
## Goal

Get a working devcontainer setup that uses the **same Go version as the GitHub Actions builds**.

## Changes

- Bump devcontainer `VARIANT` from `1.19-bullseye` to `1.26`, aligning it with:
  - `GOLANG_VERSION: "1.26"` in `.github/workflows/build.yml`
  - `go 1.26.0` in `go.mod`
- Add devcontainer features: `node` (lts), `github-cli`, and `claude-code`.
- Add `devcontainer-lock.json` to pin feature versions.

## Verification

- Confirmed the base image tag `mcr.microsoft.com/vscode/devcontainers/go:1.26` exists in the MCR registry, so the build resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration to support Node.js LTS and additional development tools.

---

**Note:** These changes are internal development infrastructure updates with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->