### PR TITLE
Add USBIP config D-Bus interface

### DIFF
--- a/config/usbip/usbip.go
+++ b/config/usbip/usbip.go
@@ -82,9 +82,9 @@ func containsNewline(values ...string) bool {
 	return false
 }
 
-// Write creates or updates the config file for the given identifier. It is an
-// upsert: an existing file is overwritten.
-func (d usbip) Write(identifier string, host string, busID string, port uint32, name string) *dbus.Error {
+// WriteRemoteDevice creates or updates the config file for the given
+// identifier. It is an upsert: an existing file is overwritten.
+func (d usbip) WriteRemoteDevice(identifier string, host string, busID string, port uint32, name string) *dbus.Error {
 	if err := validateIdentifier(identifier); err != nil {
 		return dbus.MakeFailedError(err)
 	}
@@ -112,9 +112,9 @@ func (d usbip) Write(identifier string, host string, busID string, port uint32, 
 	return nil
 }
 
-// Remove deletes the config file for the given identifier. Removing a
-// non-existent identifier is treated as success.
-func (d usbip) Remove(identifier string) *dbus.Error {
+// RemoveRemoteDevice deletes the config file for the given identifier. Removing
+// a non-existent identifier is treated as success.
+func (d usbip) RemoveRemoteDevice(identifier string) *dbus.Error {
 	if err := validateIdentifier(identifier); err != nil {
 		return dbus.MakeFailedError(err)
 	}
@@ -128,8 +128,9 @@ func (d usbip) Remove(identifier string) *dbus.Error {
 	return nil
 }
 
-// List returns the identifiers of all known remote-device config files, sorted.
-func (d usbip) List() ([]string, *dbus.Error) {
+// ListRemoteDevices returns the identifiers of all known remote-device config
+// files, sorted.
+func (d usbip) ListRemoteDevices() ([]string, *dbus.Error) {
 	entries, err := os.ReadDir(configDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/config/usbip/usbip.go
+++ b/config/usbip/usbip.go
@@ -1,0 +1,176 @@
+package usbip
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
+	"github.com/godbus/dbus/v5/prop"
+	"github.com/natefinch/atomic"
+
+	logging "github.com/home-assistant/os-agent/utils/log"
+)
+
+const (
+	objectPath  = "/io/hass/os/Config/USBIP"
+	ifaceName   = "io.hass.os.Config.USBIP"
+	defaultPort = uint32(3240)
+)
+
+var (
+	// configDir is a var (not const) so tests can redirect it to a temp dir.
+	configDir = "/run/usbip/remote-devices"
+
+	// validIdentifier restricts identifiers to a safe filename charset. A UUID
+	// (the expected caller-supplied identifier) matches this pattern.
+	validIdentifier = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+)
+
+type usbip struct {
+	conn *dbus.Conn
+}
+
+// validateIdentifier ensures the caller-supplied identifier is safe to use as
+// a filename inside configDir, guarding against path traversal.
+func validateIdentifier(identifier string) error {
+	if identifier == "" || identifier == "." || identifier == ".." {
+		return fmt.Errorf("invalid identifier %q", identifier)
+	}
+	if !validIdentifier.MatchString(identifier) {
+		return fmt.Errorf("identifier %q contains invalid characters", identifier)
+	}
+	// Defense in depth: the resolved path must stay directly inside configDir.
+	if filepath.Dir(filepath.Join(configDir, identifier)) != filepath.Clean(configDir) {
+		return fmt.Errorf("invalid identifier %q", identifier)
+	}
+	return nil
+}
+
+// buildConfig renders the systemd EnvironmentFile content for a remote device.
+func buildConfig(host, busID string, port uint32, name string) string {
+	if port == 0 {
+		port = defaultPort
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "HOST=%s\n", host)
+	fmt.Fprintf(&b, "BUSID=%s\n", busID)
+	fmt.Fprintf(&b, "PORT=%d\n", port)
+	fmt.Fprintf(&b, "NAME=%s\n", name)
+	return b.String()
+}
+
+// containsNewline reports whether any field contains a newline, which would
+// corrupt the EnvironmentFile.
+func containsNewline(values ...string) bool {
+	for _, v := range values {
+		if strings.ContainsAny(v, "\n\r") {
+			return true
+		}
+	}
+	return false
+}
+
+// Write creates or updates the config file for the given identifier. It is an
+// upsert: an existing file is overwritten.
+func (d usbip) Write(identifier string, host string, busID string, port uint32, name string) *dbus.Error {
+	if err := validateIdentifier(identifier); err != nil {
+		return dbus.MakeFailedError(err)
+	}
+	if host == "" {
+		return dbus.MakeFailedError(fmt.Errorf("host must not be empty"))
+	}
+	if busID == "" {
+		return dbus.MakeFailedError(fmt.Errorf("busID must not be empty"))
+	}
+	if containsNewline(host, busID, name) {
+		return dbus.MakeFailedError(fmt.Errorf("fields must not contain newlines"))
+	}
+
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return dbus.MakeFailedError(fmt.Errorf("failed to create config directory: %w", err))
+	}
+
+	content := buildConfig(host, busID, port, name)
+	path := filepath.Join(configDir, identifier)
+	if err := atomic.WriteFile(path, strings.NewReader(content)); err != nil {
+		return dbus.MakeFailedError(fmt.Errorf("failed to write config for %q: %w", identifier, err))
+	}
+
+	logging.Info.Printf("Wrote usbip remote-device config %s", identifier)
+	return nil
+}
+
+// Remove deletes the config file for the given identifier. Removing a
+// non-existent identifier is treated as success.
+func (d usbip) Remove(identifier string) *dbus.Error {
+	if err := validateIdentifier(identifier); err != nil {
+		return dbus.MakeFailedError(err)
+	}
+
+	path := filepath.Join(configDir, identifier)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return dbus.MakeFailedError(fmt.Errorf("failed to remove config for %q: %w", identifier, err))
+	}
+
+	logging.Info.Printf("Removed usbip remote-device config %s", identifier)
+	return nil
+}
+
+// List returns the identifiers of all known remote-device config files.
+func (d usbip) List() ([]string, *dbus.Error) {
+	entries, err := os.ReadDir(configDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, dbus.MakeFailedError(fmt.Errorf("failed to list configs: %w", err))
+	}
+
+	identifiers := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		identifiers = append(identifiers, entry.Name())
+	}
+	return identifiers, nil
+}
+
+func InitializeDBus(conn *dbus.Conn) {
+	d := usbip{
+		conn: conn,
+	}
+
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		logging.Warning.Printf("Could not create usbip config directory %s: %s", configDir, err)
+	}
+
+	err := conn.Export(d, objectPath, ifaceName)
+	if err != nil {
+		logging.Critical.Panic(err)
+	}
+
+	node := &introspect.Node{
+		Name: objectPath,
+		Interfaces: []introspect.Interface{
+			introspect.IntrospectData,
+			prop.IntrospectData,
+			{
+				Name:    ifaceName,
+				Methods: introspect.Methods(d),
+			},
+		},
+	}
+
+	err = conn.Export(introspect.NewIntrospectable(node), objectPath, "org.freedesktop.DBus.Introspectable")
+	if err != nil {
+		logging.Critical.Panic(err)
+	}
+
+	logging.Info.Printf("Exposing object %s with interface %s ...", objectPath, ifaceName)
+}

--- a/config/usbip/usbip.go
+++ b/config/usbip/usbip.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/godbus/dbus/v5"
@@ -121,7 +122,7 @@ func (d usbip) Remove(identifier string) *dbus.Error {
 	return nil
 }
 
-// List returns the identifiers of all known remote-device config files.
+// List returns the identifiers of all known remote-device config files, sorted.
 func (d usbip) List() ([]string, *dbus.Error) {
 	entries, err := os.ReadDir(configDir)
 	if err != nil {
@@ -138,6 +139,7 @@ func (d usbip) List() ([]string, *dbus.Error) {
 		}
 		identifiers = append(identifiers, entry.Name())
 	}
+	sort.Strings(identifiers)
 	return identifiers, nil
 }
 

--- a/config/usbip/usbip.go
+++ b/config/usbip/usbip.go
@@ -3,11 +3,11 @@ package usbip
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
 	"github.com/godbus/dbus/v5/prop"
@@ -42,20 +42,18 @@ type usbip struct {
 // a filename inside configDir, guarding against path traversal.
 func validateIdentifier(identifier string) error {
 	// The strict charset (no dots, slashes, or whitespace) already rules out
-	// empty, ".", "..", and any path separators.
+	// empty, ".", "..", and any path separators. configPath additionally runs
+	// the result through securejoin.SecureJoin as defense in depth.
 	if !validIdentifier.MatchString(identifier) {
 		return fmt.Errorf("identifier %q contains invalid characters", identifier)
-	}
-	// Defense in depth: the resolved path must stay directly inside configDir.
-	if filepath.Dir(filepath.Join(configDir, identifier)) != filepath.Clean(configDir) {
-		return fmt.Errorf("invalid identifier %q", identifier)
 	}
 	return nil
 }
 
-// configPath returns the on-disk path of the config file for an identifier.
-func configPath(identifier string) string {
-	return filepath.Join(configDir, identifier+configExt)
+// configPath returns the on-disk path of the config file for an identifier,
+// guaranteed by securejoin.SecureJoin to stay within configDir.
+func configPath(identifier string) (string, error) {
+	return securejoin.SecureJoin(configDir, identifier+configExt)
 }
 
 // buildConfig renders the systemd EnvironmentFile content for a remote device.
@@ -106,8 +104,12 @@ func (d usbip) WriteRemoteDevice(identifier string, host string, busID string, p
 		return dbus.MakeFailedError(fmt.Errorf("failed to create config directory: %w", err))
 	}
 
+	path, err := configPath(identifier)
+	if err != nil {
+		return dbus.MakeFailedError(fmt.Errorf("invalid identifier %q: %w", identifier, err))
+	}
+
 	content := buildConfig(host, busID, port, name)
-	path := configPath(identifier)
 	if err := atomic.WriteFile(path, strings.NewReader(content)); err != nil {
 		return dbus.MakeFailedError(fmt.Errorf("failed to write config for %q: %w", identifier, err))
 	}
@@ -123,7 +125,10 @@ func (d usbip) RemoveRemoteDevice(identifier string) *dbus.Error {
 		return dbus.MakeFailedError(err)
 	}
 
-	path := configPath(identifier)
+	path, err := configPath(identifier)
+	if err != nil {
+		return dbus.MakeFailedError(fmt.Errorf("invalid identifier %q: %w", identifier, err))
+	}
 	if err := os.Remove(path); err != nil {
 		if !os.IsNotExist(err) {
 			return dbus.MakeFailedError(fmt.Errorf("failed to remove config for %q: %w", identifier, err))

--- a/config/usbip/usbip.go
+++ b/config/usbip/usbip.go
@@ -45,6 +45,11 @@ func validateIdentifier(identifier string) error {
 	if !validIdentifier.MatchString(identifier) {
 		return fmt.Errorf("identifier %q contains invalid characters", identifier)
 	}
+	// The config extension is appended by configPath; an identifier carrying it
+	// would yield "<id>.conf.conf" on disk and an ambiguous List() result.
+	if strings.HasSuffix(identifier, configExt) {
+		return fmt.Errorf("identifier %q must not include the %q extension", identifier, configExt)
+	}
 	// Defense in depth: the resolved path must stay directly inside configDir.
 	if filepath.Dir(filepath.Join(configDir, identifier)) != filepath.Clean(configDir) {
 		return fmt.Errorf("invalid identifier %q", identifier)
@@ -97,6 +102,9 @@ func (d usbip) WriteRemoteDevice(identifier string, host string, busID string, p
 	if containsNewline(host, busID, name) {
 		return dbus.MakeFailedError(fmt.Errorf("fields must not contain newlines"))
 	}
+	if port > 65535 {
+		return dbus.MakeFailedError(fmt.Errorf("port %d out of range (0-65535)", port))
+	}
 
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		return dbus.MakeFailedError(fmt.Errorf("failed to create config directory: %w", err))
@@ -120,8 +128,11 @@ func (d usbip) RemoveRemoteDevice(identifier string) *dbus.Error {
 	}
 
 	path := configPath(identifier)
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return dbus.MakeFailedError(fmt.Errorf("failed to remove config for %q: %w", identifier, err))
+	if err := os.Remove(path); err != nil {
+		if !os.IsNotExist(err) {
+			return dbus.MakeFailedError(fmt.Errorf("failed to remove config for %q: %w", identifier, err))
+		}
+		return nil
 	}
 
 	logging.Info.Printf("Removed usbip remote-device config %s", identifier)
@@ -144,7 +155,13 @@ func (d usbip) ListRemoteDevices() ([]string, *dbus.Error) {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), configExt) {
 			continue
 		}
-		identifiers = append(identifiers, strings.TrimSuffix(entry.Name(), configExt))
+		identifier := strings.TrimSuffix(entry.Name(), configExt)
+		// Only surface identifiers we would accept ourselves, keeping List()
+		// consistent with the Write/Remove contract (e.g. drop a bare ".conf").
+		if validateIdentifier(identifier) != nil {
+			continue
+		}
+		identifiers = append(identifiers, identifier)
 	}
 	sort.Strings(identifiers)
 	return identifiers, nil

--- a/config/usbip/usbip.go
+++ b/config/usbip/usbip.go
@@ -20,6 +20,7 @@ const (
 	objectPath  = "/io/hass/os/Config/USBIP"
 	ifaceName   = "io.hass.os.Config.USBIP"
 	defaultPort = uint32(3240)
+	configExt   = ".conf"
 )
 
 var (
@@ -49,6 +50,11 @@ func validateIdentifier(identifier string) error {
 		return fmt.Errorf("invalid identifier %q", identifier)
 	}
 	return nil
+}
+
+// configPath returns the on-disk path of the config file for an identifier.
+func configPath(identifier string) string {
+	return filepath.Join(configDir, identifier+configExt)
 }
 
 // buildConfig renders the systemd EnvironmentFile content for a remote device.
@@ -97,7 +103,7 @@ func (d usbip) Write(identifier string, host string, busID string, port uint32, 
 	}
 
 	content := buildConfig(host, busID, port, name)
-	path := filepath.Join(configDir, identifier)
+	path := configPath(identifier)
 	if err := atomic.WriteFile(path, strings.NewReader(content)); err != nil {
 		return dbus.MakeFailedError(fmt.Errorf("failed to write config for %q: %w", identifier, err))
 	}
@@ -113,7 +119,7 @@ func (d usbip) Remove(identifier string) *dbus.Error {
 		return dbus.MakeFailedError(err)
 	}
 
-	path := filepath.Join(configDir, identifier)
+	path := configPath(identifier)
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return dbus.MakeFailedError(fmt.Errorf("failed to remove config for %q: %w", identifier, err))
 	}
@@ -134,10 +140,10 @@ func (d usbip) List() ([]string, *dbus.Error) {
 
 	identifiers := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if entry.IsDir() {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), configExt) {
 			continue
 		}
-		identifiers = append(identifiers, entry.Name())
+		identifiers = append(identifiers, strings.TrimSuffix(entry.Name(), configExt))
 	}
 	sort.Strings(identifiers)
 	return identifiers, nil

--- a/config/usbip/usbip.go
+++ b/config/usbip/usbip.go
@@ -28,8 +28,10 @@ var (
 	configDir = "/run/usbip/remote-devices"
 
 	// validIdentifier restricts identifiers to a safe filename charset. A UUID
-	// (the expected caller-supplied identifier) matches this pattern.
-	validIdentifier = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	// (the expected caller-supplied identifier) matches this pattern. Dots are
+	// deliberately excluded so that "", ".", "..", path separators, and any
+	// ".conf" extension can never appear in an identifier.
+	validIdentifier = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 )
 
 type usbip struct {
@@ -39,16 +41,10 @@ type usbip struct {
 // validateIdentifier ensures the caller-supplied identifier is safe to use as
 // a filename inside configDir, guarding against path traversal.
 func validateIdentifier(identifier string) error {
-	if identifier == "" || identifier == "." || identifier == ".." {
-		return fmt.Errorf("invalid identifier %q", identifier)
-	}
+	// The strict charset (no dots, slashes, or whitespace) already rules out
+	// empty, ".", "..", and any path separators.
 	if !validIdentifier.MatchString(identifier) {
 		return fmt.Errorf("identifier %q contains invalid characters", identifier)
-	}
-	// The config extension is appended by configPath; an identifier carrying it
-	// would yield "<id>.conf.conf" on disk and an ambiguous List() result.
-	if strings.HasSuffix(identifier, configExt) {
-		return fmt.Errorf("identifier %q must not include the %q extension", identifier, configExt)
 	}
 	// Defense in depth: the resolved path must stay directly inside configDir.
 	if filepath.Dir(filepath.Join(configDir, identifier)) != filepath.Clean(configDir) {

--- a/config/usbip/usbip_test.go
+++ b/config/usbip/usbip_test.go
@@ -26,7 +26,7 @@ func TestValidateIdentifier(t *testing.T) {
 	valid := []string{
 		"a1b2c3",
 		"123e4567-e89b-12d3-a456-426614174000",
-		"device_1.conf",
+		"device_1",
 	}
 	for _, id := range valid {
 		if err := validateIdentifier(id); err != nil {
@@ -43,6 +43,8 @@ func TestValidateIdentifier(t *testing.T) {
 		`a\b`,
 		"with space",
 		"new\nline",
+		"device_1.conf",
+		".conf",
 	}
 	for _, id := range invalid {
 		if err := validateIdentifier(id); err == nil {
@@ -137,5 +139,8 @@ func TestWriteValidation(t *testing.T) {
 	}
 	if derr := d.WriteRemoteDevice("dev", "host", "1-1", 0, "bad\nname"); derr == nil {
 		t.Error("Write() with newline in name should fail")
+	}
+	if derr := d.WriteRemoteDevice("dev", "host", "1-1", 65536, ""); derr == nil {
+		t.Error("Write() with out-of-range port should fail")
 	}
 }

--- a/config/usbip/usbip_test.go
+++ b/config/usbip/usbip_test.go
@@ -60,7 +60,7 @@ func TestWriteListRemove(t *testing.T) {
 	d := usbip{}
 
 	// List on a missing directory returns an empty slice, not an error.
-	ids, derr := d.List()
+	ids, derr := d.ListRemoteDevices()
 	if derr != nil {
 		t.Fatalf("List() on missing dir returned error: %v", derr)
 	}
@@ -69,7 +69,7 @@ func TestWriteListRemove(t *testing.T) {
 	}
 
 	// Write creates the file.
-	if derr := d.Write("dev-1", "10.0.0.1", "2-1", 0, "Label"); derr != nil {
+	if derr := d.WriteRemoteDevice("dev-1", "10.0.0.1", "2-1", 0, "Label"); derr != nil {
 		t.Fatalf("Write() returned error: %v", derr)
 	}
 
@@ -83,7 +83,7 @@ func TestWriteListRemove(t *testing.T) {
 	}
 
 	// Write is an upsert: overwrite the same identifier.
-	if derr := d.Write("dev-1", "10.0.0.2", "2-1", 0, "Label"); derr != nil {
+	if derr := d.WriteRemoteDevice("dev-1", "10.0.0.2", "2-1", 0, "Label"); derr != nil {
 		t.Fatalf("Write() (update) returned error: %v", derr)
 	}
 	content, _ = os.ReadFile(filepath.Join(configDir, "dev-1.conf"))
@@ -91,11 +91,11 @@ func TestWriteListRemove(t *testing.T) {
 		t.Errorf("update did not change host, got %q", string(content))
 	}
 
-	if derr := d.Write("dev-2", "10.0.0.3", "3-1", 0, ""); derr != nil {
+	if derr := d.WriteRemoteDevice("dev-2", "10.0.0.3", "3-1", 0, ""); derr != nil {
 		t.Fatalf("Write() returned error: %v", derr)
 	}
 
-	ids, derr = d.List()
+	ids, derr = d.ListRemoteDevices()
 	if derr != nil {
 		t.Fatalf("List() returned error: %v", derr)
 	}
@@ -105,7 +105,7 @@ func TestWriteListRemove(t *testing.T) {
 	}
 
 	// Remove deletes the file.
-	if derr := d.Remove("dev-1"); derr != nil {
+	if derr := d.RemoveRemoteDevice("dev-1"); derr != nil {
 		t.Fatalf("Remove() returned error: %v", derr)
 	}
 	if _, err := os.Stat(filepath.Join(configDir, "dev-1.conf")); !os.IsNotExist(err) {
@@ -113,7 +113,7 @@ func TestWriteListRemove(t *testing.T) {
 	}
 
 	// Removing a non-existent identifier is a no-op success.
-	if derr := d.Remove("dev-1"); derr != nil {
+	if derr := d.RemoveRemoteDevice("dev-1"); derr != nil {
 		t.Errorf("Remove() of missing identifier should succeed, got %v", derr)
 	}
 }
@@ -126,16 +126,16 @@ func TestWriteValidation(t *testing.T) {
 
 	d := usbip{}
 
-	if derr := d.Write("../escape", "host", "1-1", 0, ""); derr == nil {
+	if derr := d.WriteRemoteDevice("../escape", "host", "1-1", 0, ""); derr == nil {
 		t.Error("Write() with traversal identifier should fail")
 	}
-	if derr := d.Write("dev", "", "1-1", 0, ""); derr == nil {
+	if derr := d.WriteRemoteDevice("dev", "", "1-1", 0, ""); derr == nil {
 		t.Error("Write() with empty host should fail")
 	}
-	if derr := d.Write("dev", "host", "", 0, ""); derr == nil {
+	if derr := d.WriteRemoteDevice("dev", "host", "", 0, ""); derr == nil {
 		t.Error("Write() with empty busID should fail")
 	}
-	if derr := d.Write("dev", "host", "1-1", 0, "bad\nname"); derr == nil {
+	if derr := d.WriteRemoteDevice("dev", "host", "1-1", 0, "bad\nname"); derr == nil {
 		t.Error("Write() with newline in name should fail")
 	}
 }

--- a/config/usbip/usbip_test.go
+++ b/config/usbip/usbip_test.go
@@ -73,7 +73,7 @@ func TestWriteListRemove(t *testing.T) {
 		t.Fatalf("Write() returned error: %v", derr)
 	}
 
-	content, err := os.ReadFile(filepath.Join(configDir, "dev-1"))
+	content, err := os.ReadFile(filepath.Join(configDir, "dev-1.conf"))
 	if err != nil {
 		t.Fatalf("reading written config: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestWriteListRemove(t *testing.T) {
 	if derr := d.Write("dev-1", "10.0.0.2", "2-1", 0, "Label"); derr != nil {
 		t.Fatalf("Write() (update) returned error: %v", derr)
 	}
-	content, _ = os.ReadFile(filepath.Join(configDir, "dev-1"))
+	content, _ = os.ReadFile(filepath.Join(configDir, "dev-1.conf"))
 	if !strings.Contains(string(content), "HOST=10.0.0.2\n") {
 		t.Errorf("update did not change host, got %q", string(content))
 	}
@@ -108,8 +108,8 @@ func TestWriteListRemove(t *testing.T) {
 	if derr := d.Remove("dev-1"); derr != nil {
 		t.Fatalf("Remove() returned error: %v", derr)
 	}
-	if _, err := os.Stat(filepath.Join(configDir, "dev-1")); !os.IsNotExist(err) {
-		t.Errorf("file dev-1 should have been removed")
+	if _, err := os.Stat(filepath.Join(configDir, "dev-1.conf")); !os.IsNotExist(err) {
+		t.Errorf("file dev-1.conf should have been removed")
 	}
 
 	// Removing a non-existent identifier is a no-op success.

--- a/config/usbip/usbip_test.go
+++ b/config/usbip/usbip_test.go
@@ -3,7 +3,6 @@ package usbip
 import (
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 )
@@ -100,7 +99,7 @@ func TestWriteListRemove(t *testing.T) {
 	if derr != nil {
 		t.Fatalf("List() returned error: %v", derr)
 	}
-	sort.Strings(ids)
+	// List() returns identifiers sorted; assert order directly.
 	if len(ids) != 2 || ids[0] != "dev-1" || ids[1] != "dev-2" {
 		t.Errorf("List() = %v, want [dev-1 dev-2]", ids)
 	}

--- a/config/usbip/usbip_test.go
+++ b/config/usbip/usbip_test.go
@@ -45,6 +45,8 @@ func TestValidateIdentifier(t *testing.T) {
 		"new\nline",
 		"device_1.conf",
 		".conf",
+		"a.b",
+		"...",
 	}
 	for _, id := range invalid {
 		if err := validateIdentifier(id); err == nil {

--- a/config/usbip/usbip_test.go
+++ b/config/usbip/usbip_test.go
@@ -1,0 +1,142 @@
+package usbip
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestBuildConfig(t *testing.T) {
+	got := buildConfig("192.168.1.10", "1-1.2", 5000, "My Device")
+	expected := "HOST=192.168.1.10\nBUSID=1-1.2\nPORT=5000\nNAME=My Device\n"
+	if got != expected {
+		t.Errorf("buildConfig() = %q, want %q", got, expected)
+	}
+}
+
+func TestBuildConfigDefaultPort(t *testing.T) {
+	got := buildConfig("host", "1-1", 0, "")
+	if !strings.Contains(got, "PORT=3240\n") {
+		t.Errorf("buildConfig() with port 0 should default to 3240, got %q", got)
+	}
+}
+
+func TestValidateIdentifier(t *testing.T) {
+	valid := []string{
+		"a1b2c3",
+		"123e4567-e89b-12d3-a456-426614174000",
+		"device_1.conf",
+	}
+	for _, id := range valid {
+		if err := validateIdentifier(id); err != nil {
+			t.Errorf("validateIdentifier(%q) returned error: %v", id, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		".",
+		"..",
+		"a/b",
+		"../etc/passwd",
+		`a\b`,
+		"with space",
+		"new\nline",
+	}
+	for _, id := range invalid {
+		if err := validateIdentifier(id); err == nil {
+			t.Errorf("validateIdentifier(%q) expected error, got nil", id)
+		}
+	}
+}
+
+func TestWriteListRemove(t *testing.T) {
+	dir := t.TempDir()
+	old := configDir
+	configDir = filepath.Join(dir, "remote-devices")
+	defer func() { configDir = old }()
+
+	d := usbip{}
+
+	// List on a missing directory returns an empty slice, not an error.
+	ids, derr := d.List()
+	if derr != nil {
+		t.Fatalf("List() on missing dir returned error: %v", derr)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("List() on missing dir = %v, want empty", ids)
+	}
+
+	// Write creates the file.
+	if derr := d.Write("dev-1", "10.0.0.1", "2-1", 0, "Label"); derr != nil {
+		t.Fatalf("Write() returned error: %v", derr)
+	}
+
+	content, err := os.ReadFile(filepath.Join(configDir, "dev-1"))
+	if err != nil {
+		t.Fatalf("reading written config: %v", err)
+	}
+	expected := "HOST=10.0.0.1\nBUSID=2-1\nPORT=3240\nNAME=Label\n"
+	if string(content) != expected {
+		t.Errorf("config content = %q, want %q", string(content), expected)
+	}
+
+	// Write is an upsert: overwrite the same identifier.
+	if derr := d.Write("dev-1", "10.0.0.2", "2-1", 0, "Label"); derr != nil {
+		t.Fatalf("Write() (update) returned error: %v", derr)
+	}
+	content, _ = os.ReadFile(filepath.Join(configDir, "dev-1"))
+	if !strings.Contains(string(content), "HOST=10.0.0.2\n") {
+		t.Errorf("update did not change host, got %q", string(content))
+	}
+
+	if derr := d.Write("dev-2", "10.0.0.3", "3-1", 0, ""); derr != nil {
+		t.Fatalf("Write() returned error: %v", derr)
+	}
+
+	ids, derr = d.List()
+	if derr != nil {
+		t.Fatalf("List() returned error: %v", derr)
+	}
+	sort.Strings(ids)
+	if len(ids) != 2 || ids[0] != "dev-1" || ids[1] != "dev-2" {
+		t.Errorf("List() = %v, want [dev-1 dev-2]", ids)
+	}
+
+	// Remove deletes the file.
+	if derr := d.Remove("dev-1"); derr != nil {
+		t.Fatalf("Remove() returned error: %v", derr)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "dev-1")); !os.IsNotExist(err) {
+		t.Errorf("file dev-1 should have been removed")
+	}
+
+	// Removing a non-existent identifier is a no-op success.
+	if derr := d.Remove("dev-1"); derr != nil {
+		t.Errorf("Remove() of missing identifier should succeed, got %v", derr)
+	}
+}
+
+func TestWriteValidation(t *testing.T) {
+	dir := t.TempDir()
+	old := configDir
+	configDir = filepath.Join(dir, "remote-devices")
+	defer func() { configDir = old }()
+
+	d := usbip{}
+
+	if derr := d.Write("../escape", "host", "1-1", 0, ""); derr == nil {
+		t.Error("Write() with traversal identifier should fail")
+	}
+	if derr := d.Write("dev", "", "1-1", 0, ""); derr == nil {
+		t.Error("Write() with empty host should fail")
+	}
+	if derr := d.Write("dev", "host", "", 0, ""); derr == nil {
+		t.Error("Write() with empty busID should fail")
+	}
+	if derr := d.Write("dev", "host", "1-1", 0, "bad\nname"); derr == nil {
+		t.Error("Write() with newline in name should fail")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/home-assistant/os-agent/cgroup"
 	"github.com/home-assistant/os-agent/config/swap"
 	"github.com/home-assistant/os-agent/config/timesyncd"
+	"github.com/home-assistant/os-agent/config/usbip"
 	"github.com/home-assistant/os-agent/datadisk"
 	"github.com/home-assistant/os-agent/system"
 	logging "github.com/home-assistant/os-agent/utils/log"
@@ -74,6 +75,7 @@ func main() {
 	boards.InitializeDBus(conn, board)
 	swap.InitializeDBus(conn)
 	timesyncd.InitializeDBus(conn)
+	usbip.InitializeDBus(conn)
 
 	_, err = daemon.SdNotify(false, daemon.SdNotifyReady)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds a new D-Bus interface `io.hass.os.Config.USBIP` (object path `/io/hass/os/Config/USBIP`) for managing [usbip](https://aur.archlinux.org/cgit/aur.git/tree/usbip@.service?h=usbip-systemd)-style remote-device config files.

Config files are written as `/run/usbip/remote-devices/<identifier>.conf`, where `<identifier>` is a caller-supplied UUID used as the filename. Each file is a systemd **EnvironmentFile** consumed by a `usbip@<identifier>.service` template unit:

```
HOST=192.168.1.10
BUSID=1-1.2
PORT=3240
NAME=My Device
```

## Methods

| Method | Description |
| --- | --- |
| `WriteRemoteDevice(identifier, host, busID, port, name)` | Create **or** update (upsert) a config at `<identifier>.conf`. `PORT` defaults to `3240` when `0` is passed, and a port outside `0–65535` is rejected. |
| `RemoveRemoteDevice(identifier)` | Delete a config. Idempotent — removing a missing entry succeeds. |
| `ListRemoteDevices()` | Return the bare identifiers (the `.conf` suffix is stripped) of all known configs, sorted. Only entries that pass identifier validation are returned, so the output stays consistent with the write/remove contract. |

## Identifier rules

Identifiers are the filename of the config and are validated strictly to keep the on-disk path safe and the API unambiguous:

- Must match `^[A-Za-z0-9_-]+$` — ASCII letters, digits, underscore and hyphen only. A UUID passes; this is the expected form.
- **No dots.** Excluding `.` rules out `""`, `.`, `..`, any path separators, and a stray `.conf` extension in one charset check, so an identifier can never traverse outside the config dir or collide with the appended `.conf` suffix.
- Defense in depth: the resolved path must still land directly inside the config dir.
- Field values (`host`, `busID`, `name`) containing newlines are rejected so they can't corrupt the EnvironmentFile.

## Notes

- Files are written atomically (`github.com/natefinch/atomic`, already a dependency).
- Follows the existing `config/swap` and `config/timesyncd` module pattern; registered in `main.go`.
- No D-Bus policy change needed — `contrib/io.hass.conf` already covers the whole `io.hass.os` namespace.
- The `usbip@.service` template unit and unit start/stop are out of scope (handled by the caller / HAOS buildroot); this PR only manages the config files.

## Testing

- `go build ./...`, `go vet ./...` — clean
- `go test ./config/usbip/...` — passing (unit tests for `buildConfig`, identifier validation, and write/list/remove against a temp dir)
- `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a USB/IP remote-device configuration management D-Bus service for creating/updating, deleting, and listing configuration entries.
  * Config generation includes consistent `HOST`, `BUSID`, `PORT`, and `NAME` formatting with default port behavior.
* **Tests**
  * Added unit tests covering config formatting, default port handling, identifier validation (rejecting unsafe inputs), and write/list/remove persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
