### PR TITLE
Add Yellow-specific eeprom_update_unavailable blocked reason

### DIFF
--- a/boards/boards.go
+++ b/boards/boards.go
@@ -73,13 +73,13 @@ func InitializeDBus(conn *dbus.Conn, board string) {
 	switch board {
 	case "Yellow":
 		yellow.InitializeDBus(conn)
-		rpi.InitializeDBus(conn)
+		rpi.InitializeDBus(conn, board)
 	case "Green":
 		green.InitializeDBus(conn)
 	case "Supervised":
 		supervised.InitializeDBus(conn)
 	case "RaspberryPi4", "RaspberryPi5":
-		rpi.InitializeDBus(conn)
+		rpi.InitializeDBus(conn, board)
 	default:
 		logging.Info.Printf("No specific Board features for %s", board)
 	}

--- a/boards/rpi/firmware.go
+++ b/boards/rpi/firmware.go
@@ -194,7 +194,7 @@ func (d *firmware) Update() *dbus.Error {
 	// raw output. Rejecting when no update is available also keeps a no-op run
 	// from being surfaced as an applied update needing a reboot.
 	if d.state.updateBlocked {
-		return dbus.MakeFailedError(fmt.Errorf("EEPROM update is unavailable on this boot device"))
+		return dbus.MakeFailedError(fmt.Errorf("EEPROM update is unavailable on this device"))
 	}
 	if !d.state.updateAvailable {
 		return dbus.MakeFailedError(fmt.Errorf("no EEPROM update available"))

--- a/boards/rpi/firmware.go
+++ b/boards/rpi/firmware.go
@@ -47,6 +47,17 @@ func blockedReasonFor(board string) string {
 	return blockedReasonBootDevice
 }
 
+// blockedMessage returns the human-readable error for a blocked EEPROM update,
+// matching the machine-readable reason.
+func blockedMessage(reason string) string {
+	switch reason {
+	case blockedReasonBootDevice:
+		return "EEPROM update is unavailable on this boot device"
+	default:
+		return "EEPROM update is unavailable on this device"
+	}
+}
+
 type firmware struct {
 	conn     *dbus.Conn
 	props    *prop.Properties
@@ -194,7 +205,7 @@ func (d *firmware) Update() *dbus.Error {
 	// raw output. Rejecting when no update is available also keeps a no-op run
 	// from being surfaced as an applied update needing a reboot.
 	if d.state.updateBlocked {
-		return dbus.MakeFailedError(fmt.Errorf("EEPROM update is unavailable on this device"))
+		return dbus.MakeFailedError(errors.New(blockedMessage(d.state.blockedReason)))
 	}
 	if !d.state.updateAvailable {
 		return dbus.MakeFailedError(fmt.Errorf("no EEPROM update available"))

--- a/boards/rpi/firmware.go
+++ b/boards/rpi/firmware.go
@@ -25,11 +25,27 @@ const (
 	readStateTimeout = 30 * time.Second
 	updateTimeout    = 5 * time.Minute
 
+	// blockedReasonBootDevice is reported on Raspberry Pi, where a blocked
+	// update is imposed by an unsupported boot device.
 	blockedReasonBootDevice = "unsupported_boot_device"
+	// blockedReasonUnavailable is reported on a CM4-based Yellow, whose EEPROM
+	// can only be flashed via rpiboot, so an in-place update is unavailable.
+	blockedReasonUnavailable = "eeprom_update_unavailable"
 	// blockedStatusLine is the line rpi-eeprom-update prints when the current
-	// boot device cannot apply an update.
+	// hardware cannot apply an update.
 	blockedStatusLine = "BLOCKED: yes"
+
+	boardYellow = "Yellow"
 )
+
+// blockedReasonFor returns the reason a blocked EEPROM update applies to the
+// given board.
+func blockedReasonFor(board string) string {
+	if board == boardYellow {
+		return blockedReasonUnavailable
+	}
+	return blockedReasonBootDevice
+}
 
 type firmware struct {
 	conn     *dbus.Conn
@@ -116,7 +132,7 @@ func composeVersions(blCur, blLat, vlCur, vlLat string) (string, string) {
 	return blCur, blCur
 }
 
-func readState() eepromState {
+func readState(board string) eepromState {
 	ctx, cancel := context.WithTimeout(context.Background(), readStateTimeout)
 	defer cancel()
 
@@ -162,7 +178,7 @@ func readState() eepromState {
 		updateBlocked:   hasOutputLine(outStr, blockedStatusLine),
 	}
 	if state.updateBlocked {
-		state.blockedReason = blockedReasonBootDevice
+		state.blockedReason = blockedReasonFor(board)
 	}
 	return state
 }
@@ -202,8 +218,8 @@ func (d *firmware) Update() *dbus.Error {
 	return nil
 }
 
-func InitializeDBus(conn *dbus.Conn) {
-	initial := readState()
+func InitializeDBus(conn *dbus.Conn, board string) {
+	initial := readState(board)
 
 	d := &firmware{conn: conn, state: initial}
 

--- a/boards/rpi/firmware_test.go
+++ b/boards/rpi/firmware_test.go
@@ -102,6 +102,15 @@ func TestBlockedReasonFor(t *testing.T) {
 	}
 }
 
+func TestBlockedMessage(t *testing.T) {
+	if got := blockedMessage(blockedReasonBootDevice); got != "EEPROM update is unavailable on this boot device" {
+		t.Errorf("blockedMessage(bootDevice) = %q", got)
+	}
+	if got := blockedMessage(blockedReasonUnavailable); got != "EEPROM update is unavailable on this device" {
+		t.Errorf("blockedMessage(unavailable) = %q", got)
+	}
+}
+
 func TestComposeVersions(t *testing.T) {
 	cases := []struct {
 		name                       string

--- a/boards/rpi/firmware_test.go
+++ b/boards/rpi/firmware_test.go
@@ -85,6 +85,23 @@ func TestHasOutputLine(t *testing.T) {
 	}
 }
 
+func TestBlockedReasonFor(t *testing.T) {
+	cases := []struct {
+		board string
+		want  string
+	}{
+		{"Yellow", blockedReasonUnavailable},
+		{"RaspberryPi4", blockedReasonBootDevice},
+		{"RaspberryPi5", blockedReasonBootDevice},
+		{"", blockedReasonBootDevice},
+	}
+	for _, c := range cases {
+		if got := blockedReasonFor(c.board); got != c.want {
+			t.Errorf("blockedReasonFor(%q) = %q, want %q", c.board, got, c.want)
+		}
+	}
+}
+
 func TestComposeVersions(t *testing.T) {
 	cases := []struct {
 		name                       string


### PR DESCRIPTION
On a CM4-based Yellow the EEPROM can only be flashed via rpiboot, so a blocked update is not a boot-device problem - the previous "unsupported_boot_device" reason mislabeled it. Report "eeprom_update_unavailable" on Yellow while keeping "unsupported_boot_device" on Raspberry Pi, where the boot device is the actual cause.

Refs: https://github.com/home-assistant/operating-system/issues/4820

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EEPROM update status messaging for Raspberry Pi–based boards, including the Yellow board, with clearer wording about what’s unavailable.
  * Blocked-reason reporting is now tailored to the selected board, so the app presents the correct guidance when an EEPROM update can’t proceed.
  * Enhanced test coverage to ensure blocked-reason selection behaves as expected across supported board choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->