### PR TITLE
Migrate deprecated release-drafter version-resolver config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,8 @@
 name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
-version-resolver:
-  default: minor
+categories:
+  - type: version-resolver
+    semver-increment: minor
 template: |
   ## What's Changed
   


### PR DESCRIPTION
## Summary

Release-drafter runs currently emit this warning:

> Use of deprecated 'version-resolver.default' field detected. Please migrate. This field will be removed in a future release.

This migrates the config to the new v7 schema by replacing the `version-resolver.default` block with a `version-resolver`-type category without `when` conditions, which serves as the default resolver ([migration docs](https://github.com/release-drafter/release-drafter/pull/1558)).

Behavior is unchanged: releases still default to a minor version bump, and the changelog template is unaffected since version-resolver categories only influence version resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release versioning rules to determine semantic version increments through categorized release settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->