### PR TITLE
Add ListSSHAuthKeys to the System D-Bus interface

### DIFF
--- a/system/system.go
+++ b/system/system.go
@@ -167,6 +167,41 @@ func (d system) ClearSSHAuthKeys() *dbus.Error {
 	return nil
 }
 
+func listSSHAuthKeys(path string) ([]string, error) {
+	sshAuthKeyMu.Lock()
+	defer sshAuthKeyMu.Unlock()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to read SSH authorized keys file: %w", err)
+	}
+
+	keys := []string{}
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		// Skip blank and comment lines, like sshd and dropbear do
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		keys = append(keys, line)
+	}
+
+	return keys, nil
+}
+
+func (d system) ListSSHAuthKeys() ([]string, *dbus.Error) {
+	keys, err := listSSHAuthKeys(sshAuthKeyFileName)
+	if err != nil {
+		logging.Error.Printf("Failed to list SSH authorized keys: %s", err)
+		return nil, dbus.MakeFailedError(err)
+	}
+
+	return keys, nil
+}
+
 func (d system) MigrateDockerStorageDriver(backend string) *dbus.Error {
 	switch backend {
 	case "overlayfs":

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -187,6 +187,53 @@ func TestAddSSHAuthKeyConcurrent(t *testing.T) {
 	}
 }
 
+func TestListSSHAuthKeysMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+
+	keys, err := listSSHAuthKeys(path)
+	if err != nil {
+		t.Fatalf("failed to list authorized keys: %s", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("expected no keys for a missing file, got %v", keys)
+	}
+}
+
+func TestListSSHAuthKeysSkipsBlankAndCommentLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+	content := "# managed keys\n\n" + testKeyEd25519 + "\n\n  \n" + testKeyEcdsa + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to create authorized keys file: %s", err)
+	}
+
+	keys, err := listSSHAuthKeys(path)
+	if err != nil {
+		t.Fatalf("failed to list authorized keys: %s", err)
+	}
+	if len(keys) != 2 || keys[0] != testKeyEd25519 || keys[1] != testKeyEcdsa {
+		t.Errorf("unexpected keys: %v", keys)
+	}
+}
+
+func TestListSSHAuthKeysRoundtrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "authorized_keys")
+
+	if err := addSSHAuthKey(path, testKeyEd25519); err != nil {
+		t.Fatalf("failed to add first key: %s", err)
+	}
+	if err := addSSHAuthKey(path, testKeyEcdsa); err != nil {
+		t.Fatalf("failed to add second key: %s", err)
+	}
+
+	keys, err := listSSHAuthKeys(path)
+	if err != nil {
+		t.Fatalf("failed to list authorized keys: %s", err)
+	}
+	if len(keys) != 2 || keys[0] != testKeyEd25519 || keys[1] != testKeyEcdsa {
+		t.Errorf("unexpected keys: %v", keys)
+	}
+}
+
 func TestClearSSHAuthKeysRemovesFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "authorized_keys")
 	if err := os.WriteFile(path, []byte(testKeyEd25519+"\n"), 0o600); err != nil {


### PR DESCRIPTION
## Proposed change

`AddSSHAuthKey` and `ClearSSHAuthKeys` allow managing root's SSH authorized keys, but there is no way to see which keys are configured — the file is effectively write-only for API consumers. The Supervisor is growing endpoints on top of these methods (home-assistant/supervisor#7039), and without read-back a user cannot audit which keys grant access to the box, or whether any exist at all.

Add `ListSSHAuthKeys` to the `io.hass.os.System` D-Bus object, returning the `authorized_keys` entries verbatim (one string per stored line, D-Bus signature `as`). Blank and `#` comment lines are skipped, matching how sshd and dropbear read the file; a missing file returns an empty list. Reads take the same lock as modifications, so a list never observes a partially rewritten file.

This enables a `GET /os/ssh/authorized_keys` in the Supervisor and an auditable key table in the frontend, addressing the discoverability concern raised in review of the Supervisor API: with add/clear alone, keys granting root access (including ones imported via USB or written by add-ons) are invisible to the user.

Follow-up candidates deliberately not included here: `RemoveSSHAuthKey` for per-key deletion, and duplicate suppression in `AddSSHAuthKey` (now cheap to implement against the read path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for listing configured SSH authorized keys.
  * Returns valid keys in their existing order while excluding blank lines and comments.
  * Handles missing key files as an empty list and reports other access errors clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->