### PR TITLE
Improve DBus errors for ScheduleWipeDevice and MigrateDockerStorageDriver

### DIFF
--- a/system/system.go
+++ b/system/system.go
@@ -45,7 +45,8 @@ func (d system) ScheduleWipeDevice() (bool, *dbus.Error) {
 
 	data, err := os.ReadFile(kernelCommandLine)
 	if err != nil {
-		fmt.Println(err)
+		err = fmt.Errorf("failed to read kernel command line: %w", err)
+		logging.Error.Printf("%s", err)
 		return false, dbus.MakeFailedError(err)
 	}
 
@@ -54,14 +55,16 @@ func (d system) ScheduleWipeDevice() (bool, *dbus.Error) {
 
 	err = os.WriteFile(tmpKernelCommandLine, []byte(datastr), 0644) //nolint:gosec
 	if err != nil {
-		fmt.Println(err)
+		err = fmt.Errorf("failed to write kernel command line: %w", err)
+		logging.Error.Printf("%s", err)
 		return false, dbus.MakeFailedError(err)
 	}
 
 	// Boot is mounted sync on Home Assistant OS, so just rename should be fine.
 	err = os.Rename(tmpKernelCommandLine, kernelCommandLine)
 	if err != nil {
-		fmt.Println(err)
+		err = fmt.Errorf("failed to replace kernel command line: %w", err)
+		logging.Error.Printf("%s", err)
 		return false, dbus.MakeFailedError(err)
 	}
 
@@ -208,7 +211,8 @@ func (d system) MigrateDockerStorageDriver(backend string) *dbus.Error {
 		// Write the backend name to the flag file
 		err := os.WriteFile(containerdSnapshotterFlag, []byte(backend), 0644) //nolint:gosec
 		if err != nil {
-			logging.Error.Printf("Failed to write containerd snapshotter flag: %s", err)
+			err = fmt.Errorf("failed to write containerd snapshotter flag: %w", err)
+			logging.Error.Printf("%s", err)
 			return dbus.MakeFailedError(err)
 		}
 		logging.Info.Printf("Storage driver set to overlayfs containerd snapshotter")


### PR DESCRIPTION
Use nicer formatted messages for DBus errors from ScheduleWipeDevice and MigrateDockerStorageDriver, as discussed in [1].

[1] https://github.com/home-assistant/os-agent/pull/283#discussion_r3861271454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for device wipe and Docker storage migration failures.
  * Added clearer diagnostic context to logged errors, making troubleshooting easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->