### PR TITLE
Write timesyncd NTP settings to a drop-in in /etc/systemd/timesyncd.conf.d

### DIFF
--- a/config/timesyncd/timesyncd.go
+++ b/config/timesyncd/timesyncd.go
@@ -15,7 +15,9 @@ import (
 const (
 	objectPath    = "/io/hass/os/Config/Timesyncd"
 	ifaceName     = "io.hass.os.Config.Timesyncd"
-	timesyncdConf = "/etc/systemd/timesyncd.conf"
+	timesyncdConf = "/etc/systemd/timesyncd.conf.d/50-os-agent.conf"
+
+	timeSectionRegexp = `^\s*\[Time\]\s*$`
 )
 
 var (
@@ -86,7 +88,27 @@ func getTimesyncdConfigProperty(property string) []string {
 	return servers
 }
 
+// ensureTimeSection adds the [Time] section header so the drop-in is valid
+// when the file does not exist yet.
+func ensureTimeSection() error {
+	found, err := configFile.Find(timeSectionRegexp, "", true)
+	if err != nil {
+		return err
+	}
+	if found != nil {
+		return nil
+	}
+
+	var params = lineinfile.NewPresentParams("[Time]")
+	params.Regexp = regexp.MustCompile(timeSectionRegexp)
+	return configFile.Present(params)
+}
+
 func setTimesyncdConfigProperty(property string, value string) error {
+	if err := ensureTimeSection(); err != nil {
+		return fmt.Errorf("failed to set %s: %w", property, err)
+	}
+
 	var params = lineinfile.NewPresentParams(property + "=" + value)
 	params.Regexp, _ = regexp.Compile(`^\s*#?\s*(` + property + `=).*$`)
 	// Keep it simple, timesyncd.conf only has the [Time] section


### PR DESCRIPTION
Home Assistant OS persists /etc/systemd/timesyncd.conf as a single bind-mounted file. Editing it with atomic.WriteFile fails, because the temporary file has to be created in the read-only /etc/systemd. The OS now bind-mounts the /etc/systemd/timesyncd.conf.d directory instead (home-assistant/operating-system#4988) and keeps the shipped defaults in the read-only timesyncd.conf.

Write the NTP and FallbackNTP settings to 50-os-agent.conf which should be now only accessed by the OS Agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time synchronization configuration by using a dedicated systemd drop-in configuration file.
  * Ensured required time settings are added under the correct configuration section.
  * Improved error reporting when the configuration section cannot be detected or created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->