### PR TITLE
Remove NTP setting from timesyncd.conf when cleared through D-Bus

### DIFF
--- a/config/timesyncd/timesyncd.go
+++ b/config/timesyncd/timesyncd.go
@@ -43,9 +43,7 @@ func setNTPServer(c *prop.Change) *dbus.Error {
 		return dbus.MakeFailedError(fmt.Errorf("invalid type for NTPServer"))
 	}
 
-	value := strings.Join(servers, " ")
-
-	if err := setTimesyncdConfigProperty("NTP", value); err != nil {
+	if err := updateTimesyncdConfigProperty("NTP", servers); err != nil {
 		return dbus.MakeFailedError(err)
 	}
 
@@ -59,9 +57,7 @@ func setFallbackNTPServer(c *prop.Change) *dbus.Error {
 		return dbus.MakeFailedError(fmt.Errorf("invalid type for FallbackNTPServer"))
 	}
 
-	value := strings.Join(servers, " ")
-
-	if err := setTimesyncdConfigProperty("FallbackNTP", value); err != nil {
+	if err := updateTimesyncdConfigProperty("FallbackNTP", servers); err != nil {
 		return dbus.MakeFailedError(err)
 	}
 
@@ -84,6 +80,26 @@ func getTimesyncdConfigProperty(property string) []string {
 	}
 
 	return servers
+}
+
+// updateTimesyncdConfigProperty removes the property when servers is empty, so
+// lower-priority configuration (e.g. servers from DHCP) applies again.
+func updateTimesyncdConfigProperty(property string, servers []string) error {
+	if len(servers) == 0 {
+		return unsetTimesyncdConfigProperty(property)
+	}
+	return setTimesyncdConfigProperty(property, strings.Join(servers, " "))
+}
+
+func unsetTimesyncdConfigProperty(property string) error {
+	var params = lineinfile.NewAbsentParams()
+	params.Regexp, _ = regexp.Compile(`^\s*(` + property + `=).*$`)
+	params.After = `\[Time\]`
+	if err := configFile.Absent(params); err != nil {
+		return fmt.Errorf("failed to unset %s: %w", property, err)
+	}
+
+	return nil
 }
 
 func setTimesyncdConfigProperty(property string, value string) error {

--- a/config/timesyncd/timesyncd_test.go
+++ b/config/timesyncd/timesyncd_test.go
@@ -1,0 +1,119 @@
+package timesyncd
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/home-assistant/os-agent/utils/lineinfile"
+)
+
+func useTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "timesyncd.conf")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig := configFile
+	configFile = lineinfile.LineInFile{FilePath: path}
+	t.Cleanup(func() { configFile = orig })
+	return path
+}
+
+func readConfig(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(content)
+}
+
+func TestUpdateNTPAdds(t *testing.T) {
+	path := useTempConfig(t, "[Time]\nFallbackNTP=time.cloudflare.com\n")
+
+	if err := updateTimesyncdConfigProperty("NTP", []string{"pool.ntp.org", "time.google.com"}); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "[Time]\nNTP=pool.ntp.org time.google.com\nFallbackNTP=time.cloudflare.com\n"
+	if got := readConfig(t, path); got != expected {
+		t.Errorf("Expected %q, got %q", expected, got)
+	}
+}
+
+func TestUpdateNTPReplaces(t *testing.T) {
+	path := useTempConfig(t, "[Time]\nNTP=old.example.com\nFallbackNTP=time.cloudflare.com\n")
+
+	if err := updateTimesyncdConfigProperty("NTP", []string{"new.example.com"}); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "[Time]\nNTP=new.example.com\nFallbackNTP=time.cloudflare.com\n"
+	if got := readConfig(t, path); got != expected {
+		t.Errorf("Expected %q, got %q", expected, got)
+	}
+}
+
+func TestUpdateNTPEmptyRemovesLine(t *testing.T) {
+	path := useTempConfig(t, "[Time]\nNTP=old.example.com\nFallbackNTP=time.cloudflare.com\n")
+
+	if err := updateTimesyncdConfigProperty("NTP", []string{}); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "[Time]\nFallbackNTP=time.cloudflare.com\n"
+	if got := readConfig(t, path); got != expected {
+		t.Errorf("Expected %q, got %q", expected, got)
+	}
+	if servers := getNTPServers(); len(servers) != 0 {
+		t.Errorf("Expected no servers, got %v", servers)
+	}
+}
+
+func TestUpdateNTPEmptyWithoutLine(t *testing.T) {
+	path := useTempConfig(t, "[Time]\nFallbackNTP=time.cloudflare.com\n")
+
+	if err := updateTimesyncdConfigProperty("NTP", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "[Time]\nFallbackNTP=time.cloudflare.com\n"
+	if got := readConfig(t, path); got != expected {
+		t.Errorf("Expected %q, got %q", expected, got)
+	}
+}
+
+func TestUpdateFallbackNTPEmptyRemovesLine(t *testing.T) {
+	path := useTempConfig(t, "[Time]\nNTP=pool.ntp.org\nFallbackNTP=time.cloudflare.com\n")
+
+	if err := updateTimesyncdConfigProperty("FallbackNTP", []string{}); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "[Time]\nNTP=pool.ntp.org\n"
+	if got := readConfig(t, path); got != expected {
+		t.Errorf("Expected %q, got %q", expected, got)
+	}
+}
+
+func TestGetServersRoundTrip(t *testing.T) {
+	useTempConfig(t, "[Time]\n")
+
+	if err := updateTimesyncdConfigProperty("NTP", []string{"pool.ntp.org", "time.google.com"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateTimesyncdConfigProperty("FallbackNTP", []string{"time.cloudflare.com"}); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []string{"pool.ntp.org", "time.google.com"}
+	if got := getNTPServers(); !reflect.DeepEqual(got, expected) {
+		t.Errorf("Expected %v, got %v", expected, got)
+	}
+	expectedFallback := []string{"time.cloudflare.com"}
+	if got := getFallbackNTPServers(); !reflect.DeepEqual(got, expectedFallback) {
+		t.Errorf("Expected %v, got %v", expectedFallback, got)
+	}
+}

--- a/config/timesyncd/timesyncd_test.go
+++ b/config/timesyncd/timesyncd_test.go
@@ -12,7 +12,7 @@ import (
 func useTempConfig(t *testing.T, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "timesyncd.conf")
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil { //nolint:gosec
 		t.Fatal(err)
 	}
 	orig := configFile


### PR DESCRIPTION
Setting NTPServer or FallbackNTPServer to an empty list wrote an empty assignment (NTP=) into the configuration. For timesyncd an empty assignment resets the server list, so it also discarded servers from lower-priority sources.

Remove the line from the configuration file instead when the list is empty. Setting servers again adds the line back after the [Time] header.

This flaw pre-existed in #207 but with approach from #285 this could be even more problematic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time synchronization configuration handling when NTP or fallback server lists are cleared.
  * Lower-priority server settings, such as those provided through DHCP, can now apply again after custom entries are removed.

* **Tests**
  * Added coverage for adding, replacing, removing, and reading NTP and fallback server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->